### PR TITLE
Add ESM support for entrypoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ export function makeExtConfig({
           if (fs.existsSync(filePath))
             entryPoints.push({
               in: filePath,
-              out: path.join("webpackModules", wpModule)
+              out: wpModule
             });
         }
       } else {
@@ -67,7 +67,7 @@ export function makeExtConfig({
     entryPoints,
     outdir: side === "webpackModule" ? path.join(dst, "webpackModule") : dst,
 
-    format: (esm && side === "index") ? "esm" : "iife",
+    format: esm && side === "index" ? "esm" : "iife",
     globalName: "module.exports",
     platform: ["index", "webpackModule"].includes(side) ? "browser" : "node",
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const external = [
   "original-fs",
   "discord" // mappings
 ];
-const sides = ["index", "node", "host"];
+const sides = ["index", "webpackModule", "node", "host"];
 const fileExts = ["js", "jsx", "ts", "tsx"];
 
 export function makeExtConfig({
@@ -27,16 +27,19 @@ export function makeExtConfig({
   ext,
   side,
   extraExternal = [],
-  extraPlugins = []
+  extraPlugins = [],
+  esm = false
 }) {
   const entryPoints = [];
-  for (const fileExt of fileExts) {
-    const filePath = path.join(src, `${side}.${fileExt}`);
-    if (fs.existsSync(filePath)) entryPoints.push(filePath);
+  if (side !== "webpackModule") {
+    for (const fileExt of fileExts) {
+      const filePath = path.join(src, `${side}.${fileExt}`);
+      if (fs.existsSync(filePath)) entryPoints.push(filePath);
+    }
   }
 
   const wpModulesDir = path.join(src, "webpackModules");
-  if (fs.existsSync(wpModulesDir) && side === "index") {
+  if (side === "webpackModule" && fs.existsSync(wpModulesDir)) {
     const wpModules = fs.readdirSync(wpModulesDir);
     for (const wpModule of wpModules) {
       if (fs.statSync(path.join(wpModulesDir, wpModule)).isDirectory()) {
@@ -58,11 +61,11 @@ export function makeExtConfig({
 
   return {
     entryPoints,
-    outdir: dst,
+    outdir: side === "webpackModule" ? path.join(dst, "webpackModule") : dst,
 
-    format: "iife",
+    format: (esm && side === "index") ? "esm" : "iife",
     globalName: "module.exports",
-    platform: side === "index" ? "browser" : "node",
+    platform: ["index", "webpackModule"].includes(side) ? "browser" : "node",
 
     treeShaking: true,
     bundle: true,

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const external = [
   "original-fs",
   "discord" // mappings
 ];
-const sides = ["index", "webpackModule", "node", "host"];
+const sides = ["index", "webpackModules", "node", "host"];
 const fileExts = ["js", "jsx", "ts", "tsx"];
 
 export function makeExtConfig({
@@ -31,7 +31,7 @@ export function makeExtConfig({
   esm = false
 }) {
   const entryPoints = [];
-  if (side !== "webpackModule") {
+  if (side !== "webpackModules") {
     for (const fileExt of fileExts) {
       const filePath = path.join(src, `${side}.${fileExt}`);
       if (fs.existsSync(filePath)) entryPoints.push(filePath);
@@ -39,7 +39,7 @@ export function makeExtConfig({
   }
 
   const wpModulesDir = path.join(src, "webpackModules");
-  if (side === "webpackModule" && fs.existsSync(wpModulesDir)) {
+  if (side === "webpackModules" && fs.existsSync(wpModulesDir)) {
     const wpModules = fs.readdirSync(wpModulesDir);
     for (const wpModule of wpModules) {
       if (fs.statSync(path.join(wpModulesDir, wpModule)).isDirectory()) {
@@ -65,11 +65,11 @@ export function makeExtConfig({
 
   return {
     entryPoints,
-    outdir: side === "webpackModule" ? path.join(dst, "webpackModule") : dst,
+    outdir: side === "webpackModules" ? path.join(dst, "webpackModules") : dst,
 
     format: esm && side === "index" ? "esm" : "iife",
     globalName: "module.exports",
-    platform: ["index", "webpackModule"].includes(side) ? "browser" : "node",
+    platform: ["index", "webpackModules"].includes(side) ? "browser" : "node",
 
     treeShaking: true,
     bundle: true,


### PR DESCRIPTION
Also makes `webpackModules` handling separate.

I'm not sure how I feel about `esm` as the configuration key for this, it feels quite broad.